### PR TITLE
fix: compilation error

### DIFF
--- a/C/MtDec.h
+++ b/C/MtDec.h
@@ -36,7 +36,7 @@ SRes MtProgress_ProgressAdd(CMtProgress *p, UInt64 inSize, UInt64 outSize);
 SRes MtProgress_GetError(CMtProgress *p);
 void MtProgress_SetError(CMtProgress *p, SRes res);
 
-struct CMtDec_;
+typedef struct CMtDec_ CMtDec;
 
 typedef struct
 {


### PR DESCRIPTION
```sh
In file included from lzma/C/MtCoder.h:7,
from HDiffPatch/compress_plugin_demo.h:814,
from hdiffi.cpp:40:
lzma/C/MtDec.h:180:3: error: conflicting declaration 'typedef struct CMtDec_ CMtDec'
180 | } CMtDec;
|   ^~~~~~
lzma/C/MtDec.h:39:8: note: previous declaration as 'struct CMtDec'
39 | struct CMtDec;
|        ^~~~~~
make: *** [Makefile:205: hdiffi] Error 1
```